### PR TITLE
NCIATWP-10384: GA4 tag (WebPresence portal)

### DIFF
--- a/dev_index
+++ b/dev_index
@@ -14,6 +14,14 @@
     <link rel="icon" type="image/x-icon" href="common/images/favicon.ico" />
     <script src="https://assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
     <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2PTXQ845PE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-2PTXQ845PE');
+    </script>
   </head>
 
   <body>

--- a/prod_index
+++ b/prod_index
@@ -14,6 +14,14 @@
     <link rel="icon" type="image/x-icon" href="common/images/favicon.ico" />
     <script src="https://assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
     <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2PTXQ845PE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-2PTXQ845PE');
+    </script>
   </head>
 
   <body>

--- a/qa_index
+++ b/qa_index
@@ -14,6 +14,14 @@
     <link rel="icon" type="image/x-icon" href="common/images/favicon.ico" />
     <script src="https://assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
     <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2PTXQ845PE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-2PTXQ845PE');
+    </script>
   </head>
 
   <body>

--- a/stage_index
+++ b/stage_index
@@ -14,6 +14,14 @@
     <link rel="icon" type="image/x-icon" href="common/images/favicon.ico" />
     <script src="https://assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
     <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2PTXQ845PE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-2PTXQ845PE');
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
## Ticket

NCIATWP-10384 — https://tracker.nci.nih.gov/browse/NCIATWP-10384

## Summary of changes

Added the standard Google Analytics 4 (gtag.js) snippet for measurement ID `G-2PTXQ845PE` to the `<head>` of all four tier index files: `dev_index`, `qa_index`, `stage_index`, and `prod_index`. The same ID is used in every tier per convention; the GA hostname filter excludes non-prod traffic from reporting.

## Where the reviewer can test

Deploy `dev_10384` to the dev tier and load the portal. In DevTools, open the Network tab and filter on `collect` — on page load you should see a `page_view` request to `tid=G-2PTXQ845PE`.

## Other info

- Static multi-page site (Nginx, no build step, no SPA/router), so GA4's default `page_view` on each page load is sufficient — no custom events or SPA tracking added.
- No PII is sent.
- Existing Adobe DTM tag is unchanged.