### PR TITLE
NCIATWP-10384: qa → stage (GA4 portal tag)

### DIFF
--- a/dev_index
+++ b/dev_index
@@ -14,6 +14,14 @@
     <link rel="icon" type="image/x-icon" href="common/images/favicon.ico" />
     <script src="https://assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
     <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2PTXQ845PE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-2PTXQ845PE');
+    </script>
   </head>
 
   <body>

--- a/dev_index
+++ b/dev_index
@@ -589,7 +589,7 @@
             These applications were developed in collaboration between scientific stakeholders and CBIIT, with ongoing support provided by both CBIIT and the associated NCI division, office, or center.
           </p>
           <p>
-            Questions or comments? <a href="mailto:NCICBIITScientificApplicationsSupport@mail.nih.gov">Contact us via email</a>.
+            Questions or comments? <a href="mailto:NCICBIITScientificApplicationsSupport@mail.nih.gov" style="text-decoration: underline;">Contact us via email</a>.
           </p>
         </div>
       </div>

--- a/docker/frontend.dockerfile
+++ b/docker/frontend.dockerfile
@@ -7,6 +7,7 @@ RUN dnf upgrade -y --releasever=latest && \
     dnf clean all && \
     chmod 700 /usr/bin/python3.9
 
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY ${TIER}_index /usr/share/nginx/html/index.html
 COPY common/ /usr/share/nginx/html/common/
 

--- a/docker/frontend.dockerfile
+++ b/docker/frontend.dockerfile
@@ -1,8 +1,14 @@
-FROM nginx:alpine
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 ARG TIER=dev
+
+RUN dnf upgrade -y --releasever=latest && \
+    dnf install -y --releasever=latest nginx && \
+    dnf clean all
 
 COPY ${TIER}_index /usr/share/nginx/html/index.html
 COPY common/ /usr/share/nginx/html/common/
 
 EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/frontend.dockerfile
+++ b/docker/frontend.dockerfile
@@ -4,7 +4,8 @@ ARG TIER=dev
 
 RUN dnf upgrade -y --releasever=latest && \
     dnf install -y --releasever=latest nginx && \
-    dnf clean all
+    dnf clean all && \
+    chmod 700 /usr/bin/python3.9
 
 COPY ${TIER}_index /usr/share/nginx/html/index.html
 COPY common/ /usr/share/nginx/html/common/

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -9,7 +9,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://assets.adobedtm.com https://cbiit.github.io; style-src 'self' 'unsafe-inline' https://maxcdn.bootstrapcdn.com; img-src 'self' data:; font-src 'self' https://maxcdn.bootstrapcdn.com; frame-src 'self' https://cbiit.github.io;" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
     # Disable directory listing

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_tokens off;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+    # Disable directory listing
+    autoindex off;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/prod_index
+++ b/prod_index
@@ -14,6 +14,14 @@
     <link rel="icon" type="image/x-icon" href="common/images/favicon.ico" />
     <script src="https://assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
     <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2PTXQ845PE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-2PTXQ845PE');
+    </script>
   </head>
 
   <body>

--- a/prod_index
+++ b/prod_index
@@ -561,7 +561,7 @@
             These applications were developed in collaboration between scientific stakeholders and CBIIT, with ongoing support provided by both CBIIT and the associated NCI division, office, or center.
           </p>
           <p>
-            Questions or comments? <a href="mailto:NCICBIITScientificApplicationsSupport@mail.nih.gov">Contact us via email</a>.
+            Questions or comments? <a href="mailto:NCICBIITScientificApplicationsSupport@mail.nih.gov" style="text-decoration: underline;">Contact us via email</a>.
           </p>
         </div>
       </div>

--- a/qa_index
+++ b/qa_index
@@ -14,6 +14,14 @@
     <link rel="icon" type="image/x-icon" href="common/images/favicon.ico" />
     <script src="https://assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
     <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2PTXQ845PE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-2PTXQ845PE');
+    </script>
   </head>
 
   <body>

--- a/qa_index
+++ b/qa_index
@@ -589,7 +589,7 @@
             These applications were developed in collaboration between scientific stakeholders and CBIIT, with ongoing support provided by both CBIIT and the associated NCI division, office, or center.
           </p>
           <p>
-            Questions or comments? <a href="mailto:NCICBIITScientificApplicationsSupport@mail.nih.gov">Contact us via email</a>.
+            Questions or comments? <a href="mailto:NCICBIITScientificApplicationsSupport@mail.nih.gov" style="text-decoration: underline;">Contact us via email</a>.
           </p>
         </div>
       </div>

--- a/stage_index
+++ b/stage_index
@@ -14,6 +14,14 @@
     <link rel="icon" type="image/x-icon" href="common/images/favicon.ico" />
     <script src="https://assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
     <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2PTXQ845PE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', 'G-2PTXQ845PE');
+    </script>
   </head>
 
   <body>

--- a/stage_index
+++ b/stage_index
@@ -561,7 +561,7 @@
             These applications were developed in collaboration between scientific stakeholders and CBIIT, with ongoing support provided by both CBIIT and the associated NCI division, office, or center.
           </p>
           <p>
-            Questions or comments? <a href="mailto:NCICBIITScientificApplicationsSupport@mail.nih.gov">Contact us via email</a>.
+            Questions or comments? <a href="mailto:NCICBIITScientificApplicationsSupport@mail.nih.gov" style="text-decoration: underline;">Contact us via email</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Ticket
NCIATWP-10384 — https://tracker.nci.nih.gov/browse/NCIATWP-10384?filter=-1

## Summary
Promote `qa` → `stage` for the stage deployment. Carries the GA4 analytics tag (G-2PTXQ845PE) added to the portal index files (NCIATWP-10384), now present on qa.