### PR TITLE
NCIATWP-10182: Update ICD Genie name and description on WebPresence dev page

### DIFF
--- a/dev_index
+++ b/dev_index
@@ -450,15 +450,16 @@
         </div> -->
         <div class="tools-section">
           <h3>
-            <a href="https://icdgenie-dev.cancer.gov/">ICDGenie</a>
+            <a href="https://icdgenie-dev.cancer.gov/">ICD Genie</a>
           </h3>
           <div>
             ICD Genie is a web-based tool that can assist epidemiologists,
             pathologists, research assistants, and data scientists to more
             easily access, translate and validate codes and text descriptions
-            from the International Classification of Diseases (10th Edition) and
-            International Classification of Diseases for Oncology, 3rd Edition
-            (ICD-O-3).
+            from the International Classification of Diseases, 10th and 11th
+            Editions (ICD-10-CM, ICD-10-PCS, and ICD-11), and International
+            Classification of Diseases for Oncology, 3rd and 4th Editions
+            (ICD-O-3 and ICD-O-4).
           </div>
         </div>
         <div class="tools-section">


### PR DESCRIPTION
## Summary
Resolves NCIATWP-10182

## Changes
- **dev_index:** Link text updated from `ICDGenie` → `ICD Genie` (space added per AC #1)
- **dev_index:** Description updated to include ICD-10-PCS, ICD-11, and ICD-O-4 per AC #2

## New Description
> ICD Genie is a web-based tool that can assist epidemiologists, pathologists, research assistants, and data scientists to more easily access, translate and validate codes and text descriptions from the International Classification of Diseases, 10th and 11th Editions (ICD-10-CM, ICD-10-PCS, and ICD-11), and International Classification of Diseases for Oncology, 3rd and 4th Editions (ICD-O-3 and ICD-O-4).

## Testing
- Verified text matches Jira acceptance criteria exactly